### PR TITLE
fixed centering for symmetries

### DIFF
--- a/3Dmol/3dmol.js
+++ b/3Dmol/3dmol.js
@@ -248,27 +248,27 @@ $3Dmol.getExtent = function(atomlist) {
         ysum += atom.y;
         zsum += atom.z;
         
-        if (atom.symmetries) {
-            for (var n = 0; n < atom.symmetries.length; n++) {
-                xsum += atom.symmetries[n].x;
-                ysum += atom.symmetries[n].y;
-                zsum += atom.symmetries[n].x;
-                cnt++;
-                xmin = (xmin < atom.x) ? xmin : atom.x;
-                ymin = (ymin < atom.y) ? ymin : atom.y;
-                zmin = (zmin < atom.z) ? zmin : atom.z;
-                xmax = (xmax > atom.x) ? xmax : atom.x;
-                ymax = (ymax > atom.y) ? ymax : atom.y;
-                zmax = (zmax > atom.z) ? zmax : atom.z; 
-            }
-        }
-
         xmin = (xmin < atom.x) ? xmin : atom.x;
         ymin = (ymin < atom.y) ? ymin : atom.y;
         zmin = (zmin < atom.z) ? zmin : atom.z;
         xmax = (xmax > atom.x) ? xmax : atom.x;
         ymax = (ymax > atom.y) ? ymax : atom.y;
         zmax = (zmax > atom.z) ? zmax : atom.z;
+        
+        if (atom.symmetries) {
+            for (var n = 0; n < atom.symmetries.length; n++) {
+                xsum += atom.symmetries[n].x;
+                ysum += atom.symmetries[n].y;
+                zsum += atom.symmetries[n].z;
+                xmin = (xmin < atom.x) ? xmin : atom.x;
+                ymin = (ymin < atom.y) ? ymin : atom.y;
+                zmin = (zmin < atom.z) ? zmin : atom.z;
+                xmax = (xmax > atom.x) ? xmax : atom.x;
+                ymax = (ymax > atom.y) ? ymax : atom.y;
+                zmax = (zmax > atom.z) ? zmax : atom.z; 
+                cnt++;
+            }
+        }
     }
 
     return [ [ xmin, ymin, zmin ], [ xmax, ymax, zmax ],

--- a/3Dmol/parsers.js
+++ b/3Dmol/parsers.js
@@ -1008,7 +1008,7 @@ $3Dmol.Parsers = (function() {
                 var symmetries = [];
                 for (l = 0; l < copyMatrices.length; l++) {
                     var newXYZ = new $3Dmol.Vector3();
-                    newXYZ.set(atoms[t].x, atoms[t].y, atoms[t].x);
+                    newXYZ.set(atoms[t].x, atoms[t].y, atoms[t].z);
                     newXYZ.applyMatrix4(copyMatrices[l]);
                     symmetries.push(newXYZ);
                 }


### PR DESCRIPTION
The centering for molecules wasn't working properly with the "doAssembly" option because of a really simple mistake - it's fixed now.