### PR TITLE
measure xy click location relative to container, not document

### DIFF
--- a/3Dmol/glviewer.js
+++ b/3Dmol/glviewer.js
@@ -310,9 +310,10 @@ $3Dmol.GLViewer = (function() {
                     var xy = getXY(ev);
                     var x = xy[0];
                     var y = xy[1];
-                    if(x == mouseStartX && y == mouseStartY) {                    
-                        var mouseX = (x / $(window).width()) * 2 - 1;
-                        var mouseY = -(y / HEIGHT) * 2 + 1;
+                    if(x == mouseStartX && y == mouseStartY) {
+                        var offset = $(container).offset();
+                        var mouseX = ((x - offset.left) / WIDTH) * 2 - 1;
+                        var mouseY = -((y - offset.top) / HEIGHT) * 2 + 1;
                         handleClickSelection(mouseX, mouseY, ev, container);
                     }
                 }


### PR DESCRIPTION
Hi again,

I'm using the js directly on my own elements (ie. not via embedding) and my mouse clicks are all offset - they are calculated relative to the document's topleft, not the containing element's topleft.  Also, the width scaling is relative to the entire window.

These changes fix that.  I tested doc/index.html's embedded viewer ../tests/example.html with the new code and it still works as before.

Note the existing width scaling seems to be done deliberately differently to the height scaling, which works.  There may have been a reason why it was done like that.

While we're on the subject of clickable atoms, I noticed that the atoms at the end of chains cannot be clicked on (eg. try it in tests/example.html).  I'm going to take a look to see if I can understand why.