### PR TITLE
Add public function updateContainer(element) to GLViewer

### DIFF
--- a/3Dmol/glviewer.js
+++ b/3Dmol/glviewer.js
@@ -282,12 +282,8 @@ $3Dmol.GLViewer = (function() {
             HEIGHT = container.height();
             ASPECT = WIDTH / HEIGHT;
             renderer.setSize(WIDTH, HEIGHT);
-            console.log('renderer', renderer);
-            console.log('container', container, container.children());
             container.append(renderer.domElement);
-            console.log('post-append container', container, container.children());
             glDOM = $(renderer.domElement);
-            console.log('glDOM', glDOM);
 
             if (!nomouse) {
                 // user can request that the mouse handlers not be installed

--- a/3Dmol/glviewer.js
+++ b/3Dmol/glviewer.js
@@ -65,8 +65,7 @@ $3Dmol.GLViewer = (function() {
         renderer.domElement.style.position = "absolute"; //TODO: get rid of this
         renderer.domElement.style.top = "0px";
         renderer.domElement.style.zIndex = "0";
-        container.append(renderer.domElement);
-        renderer.setSize(WIDTH, HEIGHT);
+
         var camera = new $3Dmol.Camera(fov, ASPECT, NEAR, FAR);
         camera.position = new $3Dmol.Vector3(0, 0, CAMERA_Z);
         var lookingAt = new $3Dmol.Vector3();
@@ -160,8 +159,9 @@ $3Dmol.GLViewer = (function() {
         scene.fog.color = $3Dmol.CC.color(bgColor);
 
         var clickedAtom = null;
+        var glDOM = null;
+
         // enable mouse support
-        var glDOM = $(renderer.domElement);
 
         //regenerate the list of clickables
         var updateClickables = function() {
@@ -254,141 +254,175 @@ $3Dmol.GLViewer = (function() {
             t.applyQuaternion(q);
             return t;
         }
-        
-        if (!nomouse) {
-            // user can request that the mouse handlers not be installed
-            glDOM.bind('mousedown touchstart', function(ev) {
-                ev.preventDefault();
-                if (!scene)
-                    return;
+
+        // this event is bound to the body element, not the container,
+        // so no need to put it inside initContainer()
+        $('body').bind('mouseup touchend', function(ev) {
+            // handle selection
+            if(isDragging && scene) { //saw mousedown, haven't moved
                 var xy = getXY(ev);
                 var x = xy[0];
                 var y = xy[1];
-                
-                if (x === undefined)
-                    return;
-                isDragging = true;
-                clickedAtom = null;
-                mouseButton = ev.which;
-                mouseStartX = x;
-                mouseStartY = y;
-                touchDistanceStart = 0;
-                if (ev.originalEvent.targetTouches
-                        && ev.originalEvent.targetTouches.length == 2) {
-                    touchDistanceStart = calcTouchDistance(ev);
+                if(x == mouseStartX && y == mouseStartY) {
+                    var offset = $(container).offset();
+                    var mouseX = ((x - offset.left) / WIDTH) * 2 - 1;
+                    var mouseY = -((y - offset.top) / HEIGHT) * 2 + 1;
+
+                    handleClickSelection(mouseX, mouseY, ev, container);
                 }
-                cq = rotationGroup.quaternion;
-                cz = rotationGroup.position.z;
-                currentModelPos = modelGroup.position.clone();
-                cslabNear = slabNear;
-                cslabFar = slabFar;
+            }
+            
+            isDragging = false;
 
-            });
+        });
+        
+        var initContainer = function() {
 
-            glDOM.bind('DOMMouseScroll mousewheel', function(ev) { // Zoom
-                ev.preventDefault();
-                if (!scene)
-                    return;
-                var scaleFactor = (CAMERA_Z - rotationGroup.position.z) * 0.85;
-                if (ev.originalEvent.detail) { // Webkit
-                    rotationGroup.position.z += scaleFactor
-                            * ev.originalEvent.detail / 10;
-                } else if (ev.originalEvent.wheelDelta) { // Firefox
-                    rotationGroup.position.z -= scaleFactor
-                            * ev.originalEvent.wheelDelta / 400;
-                }
-                if(rotationGroup.position.z > CAMERA_Z) rotationGroup.position.z = CAMERA_Z*0.999; //avoid getting stuck
+            WIDTH = container.width();
+            HEIGHT = container.height();
+            ASPECT = WIDTH / HEIGHT;
+            renderer.setSize(WIDTH, HEIGHT);
+            container.append(renderer.domElement);
+            glDOM = $(renderer.domElement);
 
-                show();
-            });
-
-            glDOM.bind("contextmenu", function(ev) {
-                ev.preventDefault();
-            });
-            $('body').bind('mouseup touchend', function(ev) {
-                // handle selection
-                if(isDragging && scene) { //saw mousedown, haven't moved
+            if (!nomouse) {
+                // user can request that the mouse handlers not be installed
+                glDOM.bind('mousedown touchstart', function(ev) {
+                    ev.preventDefault();
+                    if (!scene)
+                        return;
                     var xy = getXY(ev);
                     var x = xy[0];
                     var y = xy[1];
-                    if(x == mouseStartX && y == mouseStartY) {
-                        var offset = $(container).offset();
-                        var mouseX = ((x - offset.left) / WIDTH) * 2 - 1;
-                        var mouseY = -((y - offset.top) / HEIGHT) * 2 + 1;
-
-                        handleClickSelection(mouseX, mouseY, ev, container);
-                    }
-                }
-                
-                isDragging = false;
-
-            });
-
-            glDOM.bind('mousemove touchmove', function(ev) { // touchmove
-                ev.preventDefault();
-                if (!scene)
-                    return;
-                if (!isDragging)
-                    return;
-                var mode = 0;
-
-                var xy = getXY(ev);
-                var x = xy[0];
-                var y = xy[1];
-                if (x === undefined)
-                    return;
-                var dx = (x - mouseStartX) / WIDTH;
-                var dy = (y - mouseStartY) / HEIGHT;
-                // check for pinch
-                if (touchDistanceStart != 0
-                        && ev.originalEvent.targetTouches
-                        && ev.originalEvent.targetTouches.length == 2) {
-                    var newdist = calcTouchDistance(ev);
-                    // change to zoom
-                    mode = 2;
-                    dy = (touchDistanceStart - newdist) * 2
-                            / (WIDTH + HEIGHT);
-                } else if (ev.originalEvent.targetTouches
-                        && ev.originalEvent.targetTouches.length == 3) {
-                    // translate
-                    mode = 1;
-                }
-
-                var r = Math.sqrt(dx * dx + dy * dy);
-                var scaleFactor;
-                if (mode == 3
-                        || (mouseButton == 3 && ev.ctrlKey)) { // Slab
-                    slabNear = cslabNear + dx * 100;
-                    slabFar = cslabFar + dy * 100;
-                } else if (mode == 2 || mouseButton == 3
-                        || ev.shiftKey) { // Zoom
-                    scaleFactor = (CAMERA_Z - rotationGroup.position.z) * 0.85;
-                    if (scaleFactor < 80)
-                        scaleFactor = 80;
-                    rotationGroup.position.z = cz - dy
-                            * scaleFactor;
-                    if(rotationGroup.position.z > CAMERA_Z) rotationGroup.position.z = CAMERA_Z*0.999; //avoid getting stuck
-                } else if (mode == 1 || mouseButton == 2
-                        || ev.ctrlKey) { // Translate
-                    var t = screenXY2model(x-mouseStartX, y-mouseStartY);
-                    modelGroup.position.addVectors(currentModelPos,t);
                     
-                } else if ((mode === 0 || mouseButton == 1)
-                        && r !== 0) { // Rotate
-                    var rs = Math.sin(r * Math.PI) / r;
-                    dq.x = Math.cos(r * Math.PI);
-                    dq.y = 0;
-                    dq.z = rs * dx;
-                    dq.w = -rs * dy;
-                    rotationGroup.quaternion = new $3Dmol.Quaternion(
-                            1, 0, 0, 0);
-                    rotationGroup.quaternion.multiply(dq);
-                    rotationGroup.quaternion.multiply(cq);
-                }
-                show();
-            });
-        }
+                    if (x === undefined)
+                        return;
+                    isDragging = true;
+                    clickedAtom = null;
+                    mouseButton = ev.which;
+                    mouseStartX = x;
+                    mouseStartY = y;
+                    touchDistanceStart = 0;
+                    if (ev.originalEvent.targetTouches
+                            && ev.originalEvent.targetTouches.length == 2) {
+                        touchDistanceStart = calcTouchDistance(ev);
+                    }
+                    cq = rotationGroup.quaternion;
+                    cz = rotationGroup.position.z;
+                    currentModelPos = modelGroup.position.clone();
+                    cslabNear = slabNear;
+                    cslabFar = slabFar;
+
+                });
+
+                glDOM.bind('DOMMouseScroll mousewheel', function(ev) { // Zoom
+                    ev.preventDefault();
+                    if (!scene)
+                        return;
+                    var scaleFactor = (CAMERA_Z - rotationGroup.position.z) * 0.85;
+                    if (ev.originalEvent.detail) { // Webkit
+                        rotationGroup.position.z += scaleFactor
+                                * ev.originalEvent.detail / 10;
+                    } else if (ev.originalEvent.wheelDelta) { // Firefox
+                        rotationGroup.position.z -= scaleFactor
+                                * ev.originalEvent.wheelDelta / 400;
+                    }
+                    if(rotationGroup.position.z > CAMERA_Z) rotationGroup.position.z = CAMERA_Z*0.999; //avoid getting stuck
+
+                    show();
+                });
+
+                glDOM.bind("contextmenu", function(ev) {
+                    ev.preventDefault();
+                });
+
+                glDOM.bind('mousemove touchmove', function(ev) { // touchmove
+                    ev.preventDefault();
+                    if (!scene)
+                        return;
+                    if (!isDragging)
+                        return;
+                    var mode = 0;
+
+                    var xy = getXY(ev);
+                    var x = xy[0];
+                    var y = xy[1];
+                    if (x === undefined)
+                        return;
+                    var dx = (x - mouseStartX) / WIDTH;
+                    var dy = (y - mouseStartY) / HEIGHT;
+                    // check for pinch
+                    if (touchDistanceStart != 0
+                            && ev.originalEvent.targetTouches
+                            && ev.originalEvent.targetTouches.length == 2) {
+                        var newdist = calcTouchDistance(ev);
+                        // change to zoom
+                        mode = 2;
+                        dy = (touchDistanceStart - newdist) * 2
+                                / (WIDTH + HEIGHT);
+                    } else if (ev.originalEvent.targetTouches
+                            && ev.originalEvent.targetTouches.length == 3) {
+                        // translate
+                        mode = 1;
+                    }
+
+                    var r = Math.sqrt(dx * dx + dy * dy);
+                    var scaleFactor;
+                    if (mode == 3
+                            || (mouseButton == 3 && ev.ctrlKey)) { // Slab
+                        slabNear = cslabNear + dx * 100;
+                        slabFar = cslabFar + dy * 100;
+                    } else if (mode == 2 || mouseButton == 3
+                            || ev.shiftKey) { // Zoom
+                        scaleFactor = (CAMERA_Z - rotationGroup.position.z) * 0.85;
+                        if (scaleFactor < 80)
+                            scaleFactor = 80;
+                        rotationGroup.position.z = cz - dy
+                                * scaleFactor;
+                        if(rotationGroup.position.z > CAMERA_Z) rotationGroup.position.z = CAMERA_Z*0.999; //avoid getting stuck
+                    } else if (mode == 1 || mouseButton == 2
+                            || ev.ctrlKey) { // Translate
+                        var t = screenXY2model(x-mouseStartX, y-mouseStartY);
+                        modelGroup.position.addVectors(currentModelPos,t);
+                        
+                    } else if ((mode === 0 || mouseButton == 1)
+                            && r !== 0) { // Rotate
+                        var rs = Math.sin(r * Math.PI) / r;
+                        dq.x = Math.cos(r * Math.PI);
+                        dq.y = 0;
+                        dq.z = rs * dx;
+                        dq.w = -rs * dy;
+                        rotationGroup.quaternion = new $3Dmol.Quaternion(
+                                1, 0, 0, 0);
+                        rotationGroup.quaternion.multiply(dq);
+                        rotationGroup.quaternion.multiply(cq);
+                    }
+                    show();
+                });
+            }
+        };
+        initContainer();
+
         // public methods
+        /**
+         * Reconnect the container element if it was removed from, and then readded to, the DOM.
+         * 
+         * @function $3Dmol.GLViewer#resetContainer
+         * 
+         * @example
+         * // Assume there exists an HTML div with id "gldiv"
+         * var element = $("#gldiv");
+         * // Create GLViewer within 'gldiv'
+         * var myviewer = $3Dmol.createViewer(element);
+         * // Remove the element from the DOM, and re-append it
+         * element.remove()
+         * $('body').prepend(element)
+         * // Reconnect the container
+         * myviewer.resetContainer(element)
+         */
+        this.resetContainer = function() {
+            initContainer();
+        };
         /**
          * Set the background color (default white)
          * 

--- a/3Dmol/glviewer.js
+++ b/3Dmol/glviewer.js
@@ -276,14 +276,18 @@ $3Dmol.GLViewer = (function() {
 
         });
         
-        var initContainer = function() {
-
+        var initContainer = function(element) {
+            container = element;
             WIDTH = container.width();
             HEIGHT = container.height();
             ASPECT = WIDTH / HEIGHT;
             renderer.setSize(WIDTH, HEIGHT);
+            console.log('renderer', renderer);
+            console.log('container', container, container.children());
             container.append(renderer.domElement);
+            console.log('post-append container', container, container.children());
             glDOM = $(renderer.domElement);
+            console.log('glDOM', glDOM);
 
             if (!nomouse) {
                 // user can request that the mouse handlers not be installed
@@ -401,27 +405,44 @@ $3Dmol.GLViewer = (function() {
                 });
             }
         };
-        initContainer();
+        initContainer(container);
 
         // public methods
         /**
-         * Reconnect the container element if it was removed from, and then readded to, the DOM.
+         * Change the viewer's container element 
+         * Also useful if the original container element was removed from the DOM.
          * 
          * @function $3Dmol.GLViewer#resetContainer
-         * 
+         *
+         * @param {Object | string} element
+         *            Either HTML element or string identifier. Defaults to the element used to initialize the viewer.
+
+         * @example
+         * // Assume there exist HTML divs with ids "gldiv", "gldiv2"
+         * var element = $("#gldiv"), element2 = $("#gldiv2");
+         * // Create GLViewer within 'gldiv'
+         * var myviewer = $3Dmol.createViewer(element);
+         * // Move the canvas to the other div
+         * myviewer.updateContainer(element2)
+         *
          * @example
          * // Assume there exists an HTML div with id "gldiv"
          * var element = $("#gldiv");
          * // Create GLViewer within 'gldiv'
          * var myviewer = $3Dmol.createViewer(element);
-         * // Remove the element from the DOM, and re-append it
+         * // Remove the element from the DOM, and add a new element
          * element.remove()
-         * $('body').prepend(element)
-         * // Reconnect the container
-         * myviewer.resetContainer(element)
+         * $('body').prepend("<div id='newdiv'></div>")
+         * // Show the canvas in the new element
+         * myviewer.updateContainer('newdiv')
          */
-        this.resetContainer = function() {
-            initContainer();
+        this.updateContainer = function(element) {
+            if($.type(element) === "string")
+                element = $("#"+element);
+            if(!element) {
+                element = container
+            };
+            initContainer(element);
         };
         /**
          * Set the background color (default white)

--- a/tests/example.html
+++ b/tests/example.html
@@ -99,7 +99,6 @@ head, body {
 </head>
 <body>
 	<div id="gldiv" style="width: 100%; height: 80vh; margin: 0; padding: 0; border: 0;"></div>
-	<div id="gldiv2" style="width: 100%; height: 80vh; margin: 0; padding: 0; border: 0;"></div>
 
 	<hr style="margin: 0;">
 

--- a/tests/example.html
+++ b/tests/example.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <title>$3Dmol Example</title>
-<script src="http://3Dmol.csb.pitt.edu/build/3Dmol-min.js"></script>
+<script src="/../build/3Dmol.js"></script>
 
 <style>
 head, body {
@@ -98,8 +98,8 @@ head, body {
 </script>
 </head>
 <body>
-	<div id="gldiv"
-		style="width: 100%; height: 80vh; margin: 0; padding: 0; border: 0;"></div>
+	<div id="gldiv" style="width: 100%; height: 80vh; margin: 0; padding: 0; border: 0;"></div>
+	<div id="gldiv2" style="width: 100%; height: 80vh; margin: 0; padding: 0; border: 0;"></div>
 
 	<hr style="margin: 0;">
 


### PR DESCRIPTION
I am using 3Dmol on a page whose DOM can change if the user clicks on an "about" or other link. When the user comes back to the molecular view, I need it to be able to show the same GLViewer again, in a new container element. (An alternative would be to just hide and re-show the container, but I'm using ReactJS to handle the view changes, and it would be hard to change its behavior.)

So, I have put some of the GLViewer constructor into a private function initContainer(element), which the constructor calls.  So far, no change in the input/output (the git change log looks long, but that's mostly because I've indented lots of lines, since they're now inside another function).

The important interface change is: there is also now a public function updateContainer(element), which reconnects the canvas and mouse clicks to the new container element.

This is working quite nicely for me.  To see it in action, you can literally use it to move the GLViewer from one DOM element to another - eg. on the tests/example.html, change the `gldiv` line to:

    <div id="gldiv" style="width: 50%; height: 80vh; margin: 0; padding: 0; border: 0; float:left"></div>
    <div id="newdiv" style="width: 50%; height: 80vh; margin: 0; padding: 0; border: 0; float:left"></div>
    <div style="clear:both"></div>

And then in the console, switch the molecule back and forth between the divs with:

    glviewer.updateContainer('newdiv')

and

    glviewer.updateContainer('gldiv')
