### PR TITLE
expand selection bug fix

### DIFF
--- a/3Dmol/glmodel.js
+++ b/3Dmol/glmodel.js
@@ -1216,8 +1216,8 @@ $3Dmol.GLModel = (function() {
             if (sel.hasOwnProperty("expand")) {
 
                 // get atoms in expanded bounding box
-                var expand = expandAtomList(ret, sel.expand)
-                var retlen = ret.length
+                var expand = expandAtomList(ret, parseFloat(sel.expand));
+                var retlen = ret.length;
                 for (var i = 0; i < expand.length; i++) {
                     for (var j = 0; j < retlen; j++) {
 
@@ -1234,13 +1234,13 @@ $3Dmol.GLModel = (function() {
             if (sel.hasOwnProperty("within") && sel.within.hasOwnProperty("sel") && sel.within.hasOwnProperty("distance")) {
 
                 // get atoms in second selection
-                var sel2 = this.selectedAtoms(sel.within.sel, atoms)
-                var within = []
+                var sel2 = this.selectedAtoms(sel.within.sel, atoms);
+                var within = [];
                 for (var i = 0; i < sel2.length; i++) {
                     for (var j = 0; j < ret.length; j++) {
 
                         var dist = squaredDistance(sel2[i], ret[j]);
-                        var thresh = Math.pow(sel.within.distance, 2);
+                        var thresh = Math.pow(parseFloat(sel.within.distance), 2);
                         if (dist < thresh && dist > 0) {
                             within.push(ret[j]);
                         }


### PR DESCRIPTION
added parseFloat() to "expand" and "within" selection keywords. Now supports these keywords in URL styling